### PR TITLE
Fix #7

### DIFF
--- a/orbit-cv.cls
+++ b/orbit-cv.cls
@@ -381,7 +381,7 @@
 
 \AtBeginShipout{\dosidebar}
 \newcommand{\makeprofile}{
-  \AtBeginShipoutFirst{\doprofile}
+  \AtBeginShipoutNext{\doprofile}
   \addfontfeatures{Color=darkgray}
   \hypersetup{
     linkcolor={sidebarbtm},


### PR DESCRIPTION
It seems probable that `tikz` had some change in behaviour, and since `atbegshi` is a somewhat hacky solution it broke. The `AtBeginShipoutNext`, when called before `\begin{document}` seems to do the same as `First` was supposed to do but in a simpler and probably more stable way. 